### PR TITLE
Adding notification when the event is about to start (5 seconds)

### DIFF
--- a/src/components/Countdown.tsx
+++ b/src/components/Countdown.tsx
@@ -7,10 +7,14 @@ interface Props {
   onFinish: () => void
   className: string
   title: string
-  beforeFinish?: number
-  onBeforeFinish?: () => void
+  actions: Action[]
   timeFormat?: string
   interval?: number
+}
+
+interface Action {
+  condition: (number: number) => boolean
+  callBack: () => void
 }
 
 const formatTime = (time: number) => {
@@ -21,15 +25,19 @@ const formatTime = (time: number) => {
 
 const roundMs = (n: number) => Math.round(n / 1000) * 1000
 
-function Countdown({ finalDate, onFinish, className, title, beforeFinish, onBeforeFinish, interval = 1000 }: Props) {
+function Countdown({ finalDate, onFinish, className, title, actions, interval = 1000 }: Props) {
   const [time, setTime] = useState<number>(roundMs(finalDate.diff(dayjs.utc(), 'milliseconds')))
 
   useInterval(
     () => {
       const remaining = roundMs(finalDate.diff(dayjs.utc(), 'milliseconds'))
-      if (beforeFinish && onBeforeFinish && remaining <= beforeFinish) {
-        onBeforeFinish()
-      }
+
+      actions.forEach(action => {
+        if (action.condition(remaining)) {
+          action.callBack()
+        }
+      })
+
       if (remaining <= 0) {
         onFinish()
       }

--- a/src/components/Countdown.tsx
+++ b/src/components/Countdown.tsx
@@ -14,7 +14,7 @@ interface Props {
 
 interface Action {
   condition: (number: number) => boolean
-  callBack: () => void
+  callback: () => void
 }
 
 const formatTime = (time: number) => {
@@ -34,7 +34,7 @@ function Countdown({ finalDate, onFinish, className, title, actions, interval = 
 
       actions.forEach(action => {
         if (action.condition(remaining)) {
-          action.callBack()
+          action.callback()
         }
       })
 

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -9,13 +9,22 @@ function Settings({ onResizableClicked }: Props) {
   const { settings, setSettings } = useSettingsContext()
   const [notify, setNotify] = useState<boolean>(settings.notify || false)
   const [notifyStart, setNotifyStart] = useState<boolean>(settings.notifyStart || false)
+  const [notifyStartTime, setNotifyStartTime] = useState<number>(settings.notifyStartTime || 30)
   const [tooltip, setTooltip] = useState<boolean>(settings.tooltip || false)
   const [special, setSpecial] = useState<boolean>(settings.special || false)
   const [resizable, setResizable] = useState<boolean>(settings.resizable || false)
 
   useEffect(() => {
-    setSettings({ notify, notifyStart, tooltip, special, resizable })
-  }, [notify, notifyStart, tooltip, special, resizable])
+    setSettings({ notify, notifyStart, notifyStartTime, tooltip, special, resizable })
+  }, [notify, notifyStart, notifyStartTime, tooltip, special, resizable])
+
+  const handleNotifyTimeChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const { min, max } = event.target
+    const value = event.target.valueAsNumber
+
+    const clampedValue = Math.max(Number(min), Math.min(Number(max), value));
+    setNotifyStartTime(isNaN(clampedValue) ? 30 : clampedValue)
+  }
 
   return (
     <div className="w-full h-screen p-2 bottom-0 nisborder border-2">
@@ -29,7 +38,17 @@ function Settings({ onResizableClicked }: Props) {
         </label>
         <label className="p-2 flex flex-row items-center">
           <input className="mr-2" type="checkbox" name="notifyStart" checked={notifyStart} onChange={() => setNotifyStart(!notifyStart)} />
-          <p>Notify when event is about to start</p>
+          <p>Notify
+            <input
+              className="mx-2 w-10 text-black"
+              type="number"
+              min="1"
+              max="300"
+              value={notifyStartTime}
+              onChange={handleNotifyTimeChange}
+            />
+            seconds before start
+          </p>
         </label>
         <label className="p-2 flex flex-row items-center">
           <input

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -8,13 +8,14 @@ interface Props {
 function Settings({ onResizableClicked }: Props) {
   const { settings, setSettings } = useSettingsContext()
   const [notify, setNotify] = useState<boolean>(settings.notify || false)
+  const [notifyStart, setNotifyStart] = useState<boolean>(settings.notifyStart || false)
   const [tooltip, setTooltip] = useState<boolean>(settings.tooltip || false)
   const [special, setSpecial] = useState<boolean>(settings.special || false)
   const [resizable, setResizable] = useState<boolean>(settings.resizable || false)
 
   useEffect(() => {
-    setSettings({ notify, tooltip, special, resizable })
-  }, [notify, tooltip, special, resizable])
+    setSettings({ notify, notifyStart, tooltip, special, resizable })
+  }, [notify, notifyStart, tooltip, special, resizable])
 
   return (
     <div className="w-full h-screen p-2 bottom-0 nisborder border-2">
@@ -25,6 +26,10 @@ function Settings({ onResizableClicked }: Props) {
         <label className="p-2 flex flex-row items-center">
           <input className="mr-2" type="checkbox" name="notify" checked={notify} onChange={() => setNotify(!notify)} />
           <p>Notify 5 minutes before start</p>
+        </label>
+        <label className="p-2 flex flex-row items-center">
+          <input className="mr-2" type="checkbox" name="notifyStart" checked={notifyStart} onChange={() => setNotifyStart(!notifyStart)} />
+          <p>Notify when event is about to start</p>
         </label>
         <label className="p-2 flex flex-row items-center">
           <input

--- a/src/components/WindowPortal.tsx
+++ b/src/components/WindowPortal.tsx
@@ -8,7 +8,7 @@ interface Props {
 }
 
 const WindowPortal = ({ children, onClose }: Props) => {
-  const externalWindow = useMemo<Window | null>(() => window.open('', '', 'width=275,height=200,left=300,top=200'), [])
+  const externalWindow = useMemo<Window | null>(() => window.open('', '', 'width=275,height=225,left=300,top=200'), [])
   const windowPortalElement = document.createElement('div')
 
   if (externalWindow) {

--- a/src/utils/settingsContext.tsx
+++ b/src/utils/settingsContext.tsx
@@ -3,13 +3,22 @@ import { createContext, PropsWithChildren, useContext, useState } from 'react'
 interface Settings {
   notify: boolean
   notifyStart: boolean,
+  notifyStartTime: number,
   tooltip: boolean
   special: boolean
   resizable: boolean
 }
 
 const useSettings = () => {
-  const defaultSettings: Settings = { notify: true, notifyStart: true, tooltip: true, special: false, resizable: true }
+  const defaultSettings: Settings = {
+    notify: true,
+    notifyStart: false,
+    notifyStartTime: 30,
+    tooltip: true,
+    special: false,
+    resizable: true
+  }
+
   const [storedSettings, setStoredSettings] = useState<Settings>(() => {
     try {
       const value = localStorage.getItem('settings')

--- a/src/utils/settingsContext.tsx
+++ b/src/utils/settingsContext.tsx
@@ -2,13 +2,14 @@ import { createContext, PropsWithChildren, useContext, useState } from 'react'
 
 interface Settings {
   notify: boolean
+  notifyStart: boolean,
   tooltip: boolean
   special: boolean
   resizable: boolean
 }
 
 const useSettings = () => {
-  const defaultSettings: Settings = { notify: true, tooltip: true, special: false, resizable: true }
+  const defaultSettings: Settings = { notify: true, notifyStart: true, tooltip: true, special: false, resizable: true }
   const [storedSettings, setStoredSettings] = useState<Settings>(() => {
     try {
       const value = localStorage.getItem('settings')


### PR DESCRIPTION
Hello! This is for the fellow players that don't have sound on and afk without sound throughout the 5 minutes till the event starts and then forget about it and look back at their screen when it's over :').

The `beforeFinish` and the `onBeforeFinish` would be very big if I added more to them so I modified in a way to be a bit more modular, making it possible to add more "actions" based on the time remaining. If you are not happy with this change I can revert it back to how it was before, but this would be really nice to even be able to add custom notifications where users can add/remove their own. If that is something you'd be fine with I could attempt to implement custom notifications.

Anyways, awesome job on the app!